### PR TITLE
Harden UI rendering paths and timeline data serialization

### DIFF
--- a/_pages/timeline.html
+++ b/_pages/timeline.html
@@ -67,14 +67,14 @@ permalink: /timeline/
     "title": {{ event.title | jsonify }},
     "summary": {{ event.summary | jsonify }},
     "details": {{ event.details | jsonify }},
-    "category": "{{ event.category }}",
+    "category": {{ event.category | jsonify }},
     "milestone": {{ event.milestone | default: false }},
     "people": {{ event.people | jsonify | default: '[]' }},
     "location": {{ event.location | jsonify }},
     "media": {{ event.media | jsonify | default: '[]' }},
     "notes": {{ event.notes | jsonify }},
     "connections": {{ event.connections | jsonify | default: '[]' }},
-    "age": "{{ event.age }}"
+    "age": {{ event.age | jsonify }}
   }{% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]

--- a/_projects/tetris.html
+++ b/_projects/tetris.html
@@ -836,7 +836,19 @@ permalink: /projects/tetris/
 
   // --- Leaderboard (global) ---
   function renderLeaderboard(list){
-    lbEl.innerHTML = (list||[]).slice(0,10).map((e,i)=>`<li>#${i+1} ${e.name} — ${e.score}</li>`).join("") || "<li>No scores yet</li>";
+    lbEl.innerHTML = "";
+    const entries = (list || []).slice(0, 10);
+    if (!entries.length) {
+      const li = document.createElement("li");
+      li.textContent = "No scores yet";
+      lbEl.appendChild(li);
+      return;
+    }
+    entries.forEach((e, i) => {
+      const li = document.createElement("li");
+      li.textContent = `#${i + 1} ${e.name} — ${e.score}`;
+      lbEl.appendChild(li);
+    });
   }
   async function fetchLeaderboard(){
     try { const r=await fetch(API_URL,{method:"GET",mode:"cors"}); const j=await r.json(); renderLeaderboard(j.leaderboard); }

--- a/assets/js/listening.js
+++ b/assets/js/listening.js
@@ -20,27 +20,66 @@
 
   function whenText(track) {
     if (track['@attr'] && track['@attr'].nowplaying) {
-      return '<span class="badge">Now Playing</span>';
+      return { text: 'Now Playing', isBadge: true };
     }
     const uts = track.date?.uts ? parseInt(track.date.uts, 10) * 1000 : null;
-    if (!uts) return '';
-    return new Date(uts).toLocaleString();
+    if (!uts) return { text: '', isBadge: false };
+    return { text: new Date(uts).toLocaleString(), isBadge: false };
   }
 
-  function rowHTML(track) {
+  function buildRow(track) {
     const artist = track.artist?.['#text'] || '';
     const title  = track.name || '';
     const url    = track.url || '#';
-    return `
-      <div class="listen-row">
-        <img alt="album art" src="${imgOf(track)}">
-        <div>
-          <div><a href="${url}" target="_blank" rel="noopener"><b>${title}</b></a></div>
-          <div class="listen-meta">${artist}</div>
-          <div class="listen-meta">${whenText(track)}</div>
-        </div>
-      </div>
-    `;
+    const time = whenText(track);
+
+    const row = document.createElement('div');
+    row.className = 'listen-row';
+
+    const image = document.createElement('img');
+    image.alt = 'album art';
+    image.src = imgOf(track);
+    row.appendChild(image);
+
+    const info = document.createElement('div');
+
+    const titleWrap = document.createElement('div');
+    const link = document.createElement('a');
+    link.href = url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    const bold = document.createElement('b');
+    bold.textContent = title;
+    link.appendChild(bold);
+    titleWrap.appendChild(link);
+    info.appendChild(titleWrap);
+
+    const artistEl = document.createElement('div');
+    artistEl.className = 'listen-meta';
+    artistEl.textContent = artist;
+    info.appendChild(artistEl);
+
+    const timeEl = document.createElement('div');
+    timeEl.className = 'listen-meta';
+    if (time.isBadge) {
+      const badge = document.createElement('span');
+      badge.className = 'badge';
+      badge.textContent = time.text;
+      timeEl.appendChild(badge);
+    } else {
+      timeEl.textContent = time.text;
+    }
+    info.appendChild(timeEl);
+
+    row.appendChild(info);
+    return row;
+  }
+
+  function renderRows(container, tracks) {
+    container.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    tracks.forEach((track) => fragment.appendChild(buildRow(track)));
+    container.appendChild(fragment);
   }
 
   async function loadRecent() {
@@ -58,21 +97,25 @@
       const np = tracks.find(t => t['@attr'] && t['@attr'].nowplaying);
       if (np) {
         $now.style.display = '';
-        $now.innerHTML = rowHTML(np);
+        renderRows($now, [np]);
       } else {
         $now.style.display = 'none';
+        $now.innerHTML = '';
       }
 
       const recent = tracks.filter(t => !(t['@attr'] && t['@attr'].nowplaying));
-      $list.innerHTML = recent.map(rowHTML).join('');
+      renderRows($list, recent);
     } catch (e) {
       clearTimeout(timeout);
       $now.style.display = '';
+      $now.innerHTML = '';
+      const message = document.createElement('div');
       if (e.name === 'AbortError') {
-        $now.innerHTML = '<div>Last.fm timed out. Try refreshing.</div>';
+        message.textContent = 'Last.fm timed out. Try refreshing.';
       } else {
-        $now.innerHTML = "<div>Couldn't load Last.fm feed.</div>";
+        message.textContent = "Couldn't load Last.fm feed.";
       }
+      $now.appendChild(message);
     }
   }
 

--- a/assets/js/timeline-app.js
+++ b/assets/js/timeline-app.js
@@ -2,14 +2,15 @@
   var dataEl = document.getElementById('timeline-data');
   if (!dataEl) return;
   var timelineData = JSON.parse(dataEl.textContent);
+  var ascending = true;
 
-  function sortEvents(ascending) {
-    return timelineData.sort(function(a, b) {
+  function sortEvents(events, asc) {
+    return events.slice().sort(function(a, b) {
       var partsA = a.date.split('-');
       var dateA = new Date(partsA[0], partsA[1] - 1, partsA[2]);
       var partsB = b.date.split('-');
       var dateB = new Date(partsB[0], partsB[1] - 1, partsB[2]);
-      return ascending ? dateA - dateB : dateB - dateA;
+      return asc ? dateA - dateB : dateB - dateA;
     });
   }
 
@@ -47,7 +48,10 @@
     container.innerHTML = '';
 
     if (events.length === 0) {
-      container.innerHTML = '<div class="timeline-empty">No events found matching your criteria</div>';
+      var empty = document.createElement('div');
+      empty.className = 'timeline-empty';
+      empty.textContent = 'No events found matching your criteria';
+      container.appendChild(empty);
       return;
     }
 
@@ -76,41 +80,79 @@
         year: 'numeric', month: 'short', day: 'numeric'
       });
 
-      var html = '<div class="timeline-date">' + dateStr + '</div>' +
-        '<span class="timeline-category">' + event.category + '</span>' +
-        (event.age ? '<span class="timeline-age">Age ' + event.age + '</span>' : '') +
-        '<h3 class="timeline-title">' + event.title + '</h3>' +
-        '<div class="timeline-summary">' + event.summary + '</div>';
+      var date = document.createElement('div');
+      date.className = 'timeline-date';
+      date.textContent = dateStr;
+      content.appendChild(date);
+
+      var category = document.createElement('span');
+      category.className = 'timeline-category';
+      category.textContent = event.category || '';
+      content.appendChild(category);
+
+      if (event.age) {
+        var age = document.createElement('span');
+        age.className = 'timeline-age';
+        age.textContent = 'Age ' + event.age;
+        content.appendChild(age);
+      }
+
+      var title = document.createElement('h3');
+      title.className = 'timeline-title';
+      title.textContent = event.title || '';
+      content.appendChild(title);
+
+      var summary = document.createElement('div');
+      summary.className = 'timeline-summary';
+      summary.textContent = event.summary || '';
+      content.appendChild(summary);
 
       if (event.details) {
-        html += '<div class="timeline-details">' + event.details + '</div>';
+        var details = document.createElement('div');
+        details.className = 'timeline-details';
+        details.textContent = event.details;
+        content.appendChild(details);
       }
 
       if (event.people && event.people.length > 0) {
-        html += '<div class="timeline-people">';
+        var people = document.createElement('div');
+        people.className = 'timeline-people';
         event.people.forEach(function(person) {
-          html += '<span class="person-tag" tabindex="0">' + person + '</span>';
+          var tag = document.createElement('span');
+          tag.className = 'person-tag';
+          tag.setAttribute('tabindex', '0');
+          tag.textContent = person;
+          people.appendChild(tag);
         });
-        html += '</div>';
+        content.appendChild(people);
       }
 
       if (event.media && event.media.length > 0) {
-        html += '<div class="timeline-media">';
+        var media = document.createElement('div');
+        media.className = 'timeline-media';
         event.media.forEach(function(img) {
-          html += '<img src="' + img + '" alt="Memory" loading="lazy">';
+          var image = document.createElement('img');
+          image.src = img;
+          image.alt = 'Memory';
+          image.loading = 'lazy';
+          media.appendChild(image);
         });
-        html += '</div>';
+        content.appendChild(media);
       }
 
       if (event.notes) {
-        html += '<div class="timeline-notes">' + event.notes + '</div>';
+        var notes = document.createElement('div');
+        notes.className = 'timeline-notes';
+        notes.textContent = event.notes;
+        content.appendChild(notes);
       }
 
       if (event.connections && event.connections.length > 0) {
-        html += '<div class="timeline-connections">' + event.connections.join(', ') + '</div>';
+        var connections = document.createElement('div');
+        connections.className = 'timeline-connections';
+        connections.textContent = event.connections.join(', ');
+        content.appendChild(connections);
       }
-
-      content.innerHTML = html;
 
       function toggleExpand() {
         var expanded = content.classList.toggle('expanded');
@@ -150,7 +192,16 @@
   function getFiltered() {
     var searchTerm = document.getElementById('timeline-search').value;
     var category = document.getElementById('category-filter').value;
-    return filterEvents(searchTerm, category);
+    return sortEvents(filterEvents(searchTerm, category), ascending);
+  }
+
+  function setSortButtons() {
+    var ascBtn = document.getElementById('sort-asc');
+    var descBtn = document.getElementById('sort-desc');
+    ascBtn.classList.toggle('active', ascending);
+    descBtn.classList.toggle('active', !ascending);
+    ascBtn.setAttribute('aria-pressed', ascending ? 'true' : 'false');
+    descBtn.setAttribute('aria-pressed', ascending ? 'false' : 'true');
   }
 
   document.getElementById('timeline-search').addEventListener('input', function() {
@@ -166,28 +217,28 @@
   });
 
   document.getElementById('sort-asc').addEventListener('click', function() {
-    this.classList.add('active');
-    document.getElementById('sort-desc').classList.remove('active');
-    sortEvents(true);
+    ascending = true;
+    setSortButtons();
     renderTimeline(getFiltered());
   });
 
   document.getElementById('sort-desc').addEventListener('click', function() {
-    this.classList.add('active');
-    document.getElementById('sort-asc').classList.remove('active');
-    sortEvents(false);
+    ascending = false;
+    setSortButtons();
     renderTimeline(getFiltered());
   });
 
   document.getElementById('show-all').addEventListener('click', function() {
     document.getElementById('timeline-search').value = '';
     document.getElementById('category-filter').value = 'all';
-    renderTimeline(timelineData);
-    updateStats(timelineData);
+    var filtered = getFiltered();
+    renderTimeline(filtered);
+    updateStats(filtered);
   });
 
   // Initial render
-  sortEvents(true);
-  renderTimeline(timelineData);
-  updateStats(timelineData);
+  setSortButtons();
+  var initial = getFiltered();
+  renderTimeline(initial);
+  updateStats(initial);
 })();


### PR DESCRIPTION
### Motivation
- Eliminate XSS and brittle HTML injection by avoiding string-based `innerHTML` for content that can include external or user-provided data.
- Prevent timeline breakage caused by fragile JSON embedded in the page by ensuring all fields are serialized safely.
- Fix UX/accessibility regressions where sorting mutated the source array in-place and sort control `aria-pressed` could drift from visual state.

### Description
- Replaced string `innerHTML` templates with DOM node construction in `assets/js/timeline-app.js` to render timeline items safely and avoid XSS vectors.
- Hardened the timeline JSON payload in `_pages/timeline.html` by applying `| jsonify` to `category` and `age` so embedded JSON cannot be broken by quotes or special characters.
- Stopped in-place timeline sorting by sorting copies (`slice().sort(...)`), introduced an `ascending` state, and synchronized sort buttons' visual state with `aria-pressed` via `setSortButtons()` in `assets/js/timeline-app.js`.
- Replaced string-based row rendering in `assets/js/listening.js` with safe DOM construction and added robust error/timeout rendering, and updated `_projects/tetris.html` leaderboard rendering to use DOM APIs rather than HTML string concatenation.

### Testing
- Ran JavaScript syntax checks with `node --check assets/js/timeline-app.js` and `node --check assets/js/listening.js`, and both checks completed successfully.
- Attempted a site build with `bundle exec jekyll build`, but it failed in this environment because the `jekyll` executable is not available (install gems with `bundle install` then re-run `bundle exec jekyll build`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdffd07ac4832193651607a41931eb)