### PR TITLE
Integrate pretext library for text wrapping, poetry Game of Life, and quotes gravity sim

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,6 +33,7 @@
   <script defer src="{{ '/assets/js/site-optimizations.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/pretext-flow.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/poetry-life.js' | relative_url }}"></script>
+  <script defer src="{{ '/assets/js/quotes-gravity.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/no-flash.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/nav.js' | relative_url }}"></script>
   <script defer src="{{ '/assets/js/footer-subscribe.js' | relative_url }}"></script>

--- a/_layouts/quotes.html
+++ b/_layouts/quotes.html
@@ -1,0 +1,22 @@
+---
+layout: default
+---
+<article class="post quotes-post">
+  <h1>{{ page.title }}</h1>
+  <p class="post-meta">Posted on {{ page.date | date: "%B %-d, %Y" }}</p>
+  <div class="quotes-gravity" data-quotes>
+    <div class="quote-source">{{ content }}</div>
+    <canvas class="gravity-canvas"></canvas>
+    <p class="gravity-hint">drag to attract &middot; click to scatter &middot; double-click to reform</p>
+  </div>
+</article>
+<hr>
+<section id="comments">
+  <script src="https://utteranc.es/client.js"
+          repo="lxsoftroxs/lxsoftroxs.github.io"
+          issue-term="pathname"
+          theme="github-dark"
+          crossorigin="anonymous"
+          async>
+  </script>
+</section>

--- a/_pages/quotes.md
+++ b/_pages/quotes.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: quotes
 title: Quotes
 date: 2025-10-18
 permalink: /quotes/

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -521,6 +521,43 @@ img {
   letter-spacing: 0.05em;
 }
 
+/* ============================================================
+   Quotes N-body gravity canvas
+   ============================================================ */
+.quotes-gravity {
+  position: relative;
+  min-height: 400px;
+}
+
+.quotes-gravity .quote-source {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.gravity-canvas {
+  display: block;
+  margin: 0 auto;
+  cursor: crosshair;
+  border: 1px solid rgba(102, 221, 255, 0.06);
+  border-radius: 4px;
+  background: radial-gradient(ellipse at 50% 40%, rgba(15, 25, 40, 0.9), rgba(0, 0, 0, 0.95));
+}
+
+.gravity-hint {
+  text-align: center;
+  color: #555;
+  font-size: 0.75em;
+  margin-top: 8px;
+  letter-spacing: 0.05em;
+}
+
 /* Mirror-ball visual (used by pretext-flow.js) */
 .flow-mirror-ball {
   --size: 86px;

--- a/assets/js/quotes-gravity.js
+++ b/assets/js/quotes-gravity.js
@@ -1,0 +1,366 @@
+/* quotes-gravity.js — N-body gravity simulation where every letter is a
+   particle.  Uses @chenglou/pretext to compute the initial character grid,
+   then runs pairwise gravitational physics with spatial-hash acceleration.
+   Characters scatter, orbit, cluster, then slowly reform into readable
+   quotes — an endless gravitational ballet of words. */
+(async function () {
+  /* ── Early exit ────────────────────────────────────────────── */
+  var wrap = document.querySelector('.quotes-gravity[data-quotes]');
+  if (!wrap) return;
+
+  /* ── Load pretext ──────────────────────────────────────────── */
+  var pt;
+  try {
+    pt = await import('https://cdn.jsdelivr.net/npm/@chenglou/pretext/+esm');
+  } catch (e) {
+    console.warn('[quotes-gravity] pretext unavailable:', e);
+    return;
+  }
+
+  /* ── DOM ────────────────────────────────────────────────────── */
+  var source = wrap.querySelector('.quote-source');
+  if (!source) return;
+
+  var canvas = wrap.querySelector('.gravity-canvas');
+  if (!canvas) return;
+  var ctx = canvas.getContext('2d');
+
+  /* ── Parse quotes into separate groups ─────────────────────── */
+  var quoteEls = source.querySelectorAll('p');
+  var quotes = [];
+  for (var qi = 0; qi < quoteEls.length; qi++) {
+    var t = quoteEls[qi].innerText.trim();
+    if (t) quotes.push(t);
+  }
+  if (!quotes.length) return;
+
+  /* ── Neon palette — one colour per quote ───────────────────── */
+  var COLORS = [
+    '#6df', '#f7a', '#af6', '#d8f', '#fd6',
+    '#6ff', '#fa8', '#88f', '#f88', '#8f8', '#f8d'
+  ];
+
+  /* ── Font metrics ──────────────────────────────────────────── */
+  var fontSize = 13;
+  var font = fontSize + 'px "Courier New", Courier, monospace';
+  var lh = Math.round(fontSize * 1.7);
+  ctx.font = font;
+  var cw = ctx.measureText('M').width;
+
+  /* ── Canvas sizing ─────────────────────────────────────────── */
+  var dpr = window.devicePixelRatio || 1;
+  var W, H;
+
+  function sizeCanvas() {
+    W = wrap.clientWidth || 760;
+    H = Math.max(500, window.innerHeight * 0.7);
+    canvas.width  = Math.round(W * dpr);
+    canvas.height = Math.round(H * dpr);
+    canvas.style.width  = W + 'px';
+    canvas.style.height = H + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+  sizeCanvas();
+
+  /* ── Use pretext to layout all quotes and map characters ───── */
+  var N = 0;            // total particle count
+  var maxW = W - 20;    // text area width with small padding
+
+  // First pass: count characters
+  var charData = [];    // { ch, qIdx, hx, hy }
+  var yOff = 20;
+
+  for (var qi = 0; qi < quotes.length; qi++) {
+    var text = quotes[qi];
+    var prepared = pt.prepareWithSegments(text, font, { whiteSpace: 'pre-wrap' });
+    var layout = pt.layoutWithLines(prepared, maxW, lh);
+
+    for (var li = 0; li < layout.lines.length; li++) {
+      var lineText = layout.lines[li].text;
+      var x = 10;
+      for (var ci = 0; ci < lineText.length; ci++) {
+        var ch = lineText[ci];
+        if (ch !== ' ' && ch !== '\t') {
+          charData.push({ ch: ch, qIdx: qi, hx: x + cw * 0.5, hy: yOff + lh * 0.5 });
+        }
+        x += cw;
+      }
+      yOff += lh;
+    }
+    yOff += lh;   // gap between quotes
+  }
+
+  N = charData.length;
+  if (!N) return;
+
+  /* ── Particle arrays (typed for speed) ─────────────────────── */
+  var px = new Float32Array(N);   // position x
+  var py = new Float32Array(N);   // position y
+  var vx = new Float32Array(N);   // velocity x
+  var vy = new Float32Array(N);   // velocity y
+  var hx = new Float32Array(N);   // home x
+  var hy = new Float32Array(N);   // home y
+  var ch = new Array(N);          // character
+  var qi_arr = new Uint8Array(N); // quote index
+
+  for (var i = 0; i < N; i++) {
+    var d = charData[i];
+    px[i] = hx[i] = d.hx;
+    py[i] = hy[i] = d.hy;
+    vx[i] = vy[i] = 0;
+    ch[i] = d.ch;
+    qi_arr[i] = d.qIdx;
+  }
+  charData = null; // free
+
+  /* ── Physics constants ─────────────────────────────────────── */
+  var G           = 40;       // gravitational constant
+  var SOFTENING   = 600;      // softening term (r^2 + SOFTENING)
+  var REPULSE_R   = 8;        // repulsion cutoff distance
+  var REPULSE_K   = 3000;     // repulsion strength
+  var DAMPING     = 0.992;    // velocity damping per frame
+  var HOME_BASE   = 0;        // current homing spring constant
+  var HOME_MAX    = 0.025;    // max homing spring constant
+  var MOUSE_FORCE = 8000;     // mouse attraction strength
+  var SCATTER_VEL = 6;        // velocity added on scatter-click
+  var DT          = 0.6;      // integration timestep
+
+  /* ── Spatial hash ──────────────────────────────────────────── */
+  var CELL = 90;
+  var hashMap = new Map();
+
+  function cellKey(cx, cy) { return (cx + 5000) * 10001 + (cy + 5000); }
+
+  function buildHash() {
+    hashMap.clear();
+    for (var i = 0; i < N; i++) {
+      var cx = Math.floor(px[i] / CELL);
+      var cy = Math.floor(py[i] / CELL);
+      var key = cellKey(cx, cy);
+      var bucket = hashMap.get(key);
+      if (!bucket) { bucket = []; hashMap.set(key, bucket); }
+      bucket.push(i);
+    }
+  }
+
+  /* ── Physics step ──────────────────────────────────────────── */
+  function physics() {
+    buildHash();
+
+    // Accumulators
+    var ax = new Float32Array(N);
+    var ay = new Float32Array(N);
+
+    // Gravity + repulsion via spatial hash (nearby cells only)
+    for (var i = 0; i < N; i++) {
+      var cx = Math.floor(px[i] / CELL);
+      var cy = Math.floor(py[i] / CELL);
+
+      for (var dx = -1; dx <= 1; dx++) {
+        for (var dy = -1; dy <= 1; dy++) {
+          var bucket = hashMap.get(cellKey(cx + dx, cy + dy));
+          if (!bucket) continue;
+
+          for (var bi = 0; bi < bucket.length; bi++) {
+            var j = bucket[bi];
+            if (j <= i) continue;    // each pair once
+
+            var ddx = px[j] - px[i];
+            var ddy = py[j] - py[i];
+            var r2  = ddx * ddx + ddy * ddy;
+
+            // Gravity (attractive)
+            var f = G / (r2 + SOFTENING);
+            ax[i] += f * ddx;   ay[i] += f * ddy;
+            ax[j] -= f * ddx;   ay[j] -= f * ddy;
+
+            // Short-range repulsion
+            if (r2 < REPULSE_R * REPULSE_R && r2 > 0.1) {
+              var rf = -REPULSE_K / (r2 + 10);
+              ax[i] += rf * ddx;   ay[i] += rf * ddy;
+              ax[j] -= rf * ddx;   ay[j] -= rf * ddy;
+            }
+          }
+        }
+      }
+    }
+
+    // Homing force + mouse + integrate
+    for (var i = 0; i < N; i++) {
+      // Homing spring
+      ax[i] += HOME_BASE * (hx[i] - px[i]);
+      ay[i] += HOME_BASE * (hy[i] - py[i]);
+
+      // Mouse attraction
+      if (mouseDown && mouseX > 0) {
+        var mdx = mouseX - px[i];
+        var mdy = mouseY - py[i];
+        var mr2 = mdx * mdx + mdy * mdy + 400;
+        var mf  = MOUSE_FORCE / mr2;
+        ax[i] += mf * mdx;
+        ay[i] += mf * mdy;
+      }
+
+      // Integrate (semi-implicit Euler)
+      vx[i] = (vx[i] + ax[i] * DT) * DAMPING;
+      vy[i] = (vy[i] + ay[i] * DT) * DAMPING;
+      px[i] += vx[i] * DT;
+      py[i] += vy[i] * DT;
+
+      // Soft boundary bounce
+      if (px[i] < 5)     { px[i] = 5;     vx[i] *= -0.5; }
+      if (px[i] > W - 5) { px[i] = W - 5; vx[i] *= -0.5; }
+      if (py[i] < 5)     { py[i] = 5;     vy[i] *= -0.5; }
+      if (py[i] > H - 5) { py[i] = H - 5; vy[i] *= -0.5; }
+    }
+  }
+
+  /* ── Render ────────────────────────────────────────────────── */
+  function draw() {
+    ctx.clearRect(0, 0, W, H);
+    ctx.font = font;
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'center';
+
+    for (var i = 0; i < N; i++) {
+      var color = COLORS[qi_arr[i] % COLORS.length];
+      ctx.fillStyle = color;
+      ctx.shadowColor = color;
+      ctx.shadowBlur = 3;
+      ctx.fillText(ch[i], px[i], py[i]);
+    }
+    ctx.shadowBlur = 0;
+  }
+
+  /* ── Phase management ──────────────────────────────────────── */
+  var PHASE_READ   = 0;
+  var PHASE_DRIFT  = 1;
+  var PHASE_REFORM = 2;
+
+  var phase     = PHASE_READ;
+  var phaseTime = 0;
+  var readMs    = 4000;    // hold readable text
+  var driftMs   = 18000;   // free gravitational drift
+  var reformMs  = 6000;    // spring back to readable
+
+  function updatePhase(dt) {
+    phaseTime += dt;
+
+    if (phase === PHASE_READ) {
+      HOME_BASE = HOME_MAX;
+      if (phaseTime > readMs) { phase = PHASE_DRIFT; phaseTime = 0; }
+    } else if (phase === PHASE_DRIFT) {
+      // Ease homing out over first 2s, then keep at 0
+      var t = Math.min(phaseTime / 2000, 1);
+      HOME_BASE = HOME_MAX * (1 - t * t);
+      if (phaseTime > driftMs) { phase = PHASE_REFORM; phaseTime = 0; }
+    } else if (phase === PHASE_REFORM) {
+      // Ease homing back in
+      var t = Math.min(phaseTime / reformMs, 1);
+      HOME_BASE = HOME_MAX * t * t;
+      if (phaseTime > reformMs) { phase = PHASE_READ; phaseTime = 0; }
+    }
+  }
+
+  /* ── Mouse state ───────────────────────────────────────────── */
+  var mouseX = -999, mouseY = -999;
+  var mouseDown = false;
+
+  canvas.addEventListener('mousemove', function (e) {
+    var r = canvas.getBoundingClientRect();
+    mouseX = e.clientX - r.left;
+    mouseY = e.clientY - r.top;
+  });
+  canvas.addEventListener('mouseleave', function () { mouseX = -999; mouseDown = false; });
+  canvas.addEventListener('mousedown', function () { mouseDown = true; });
+  canvas.addEventListener('mouseup', function ()   { mouseDown = false; });
+
+  canvas.addEventListener('touchstart', function (e) {
+    if (e.touches[0]) {
+      var r = canvas.getBoundingClientRect();
+      mouseX = e.touches[0].clientX - r.left;
+      mouseY = e.touches[0].clientY - r.top;
+      mouseDown = true;
+    }
+  }, { passive: true });
+  canvas.addEventListener('touchmove', function (e) {
+    if (e.touches[0]) {
+      var r = canvas.getBoundingClientRect();
+      mouseX = e.touches[0].clientX - r.left;
+      mouseY = e.touches[0].clientY - r.top;
+    }
+  }, { passive: true });
+  canvas.addEventListener('touchend', function () { mouseDown = false; }, { passive: true });
+
+  /* Click → scatter burst */
+  canvas.addEventListener('click', function () {
+    for (var i = 0; i < N; i++) {
+      var angle = Math.random() * Math.PI * 2;
+      vx[i] += Math.cos(angle) * SCATTER_VEL * (1 + Math.random());
+      vy[i] += Math.sin(angle) * SCATTER_VEL * (1 + Math.random());
+    }
+    phase = PHASE_DRIFT;
+    phaseTime = 0;
+  });
+
+  /* Double-click → reform immediately */
+  canvas.addEventListener('dblclick', function () {
+    phase = PHASE_REFORM;
+    phaseTime = 0;
+  });
+
+  /* ── Animation loop ────────────────────────────────────────── */
+  var lastT = 0;
+
+  function animate(ts) {
+    var dt = lastT ? (ts - lastT) : 16;
+    lastT = ts;
+    if (dt > 50) dt = 50;   // cap to prevent spiral on tab-switch
+
+    updatePhase(dt);
+    physics();
+    draw();
+
+    requestAnimationFrame(animate);
+  }
+
+  /* ── First paint (readable) then go ────────────────────────── */
+  HOME_BASE = HOME_MAX;
+  draw();
+  requestAnimationFrame(animate);
+
+  /* ── Resize ────────────────────────────────────────────────── */
+  var resizeTimer;
+  window.addEventListener('resize', function () {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      sizeCanvas();
+      // Recalculate home positions
+      maxW = W - 20;
+      var newData = [];
+      var yOff = 20;
+      for (var qi = 0; qi < quotes.length; qi++) {
+        var text = quotes[qi];
+        var prepared = pt.prepareWithSegments(text, font, { whiteSpace: 'pre-wrap' });
+        var layout = pt.layoutWithLines(prepared, maxW, lh);
+        for (var li = 0; li < layout.lines.length; li++) {
+          var lineText = layout.lines[li].text;
+          var x = 10;
+          for (var ci = 0; ci < lineText.length; ci++) {
+            if (lineText[ci] !== ' ' && lineText[ci] !== '\t') {
+              newData.push({ hx: x + cw * 0.5, hy: yOff + lh * 0.5 });
+            }
+            x += cw;
+          }
+          yOff += lh;
+        }
+        yOff += lh;
+      }
+      // Update home positions (particle count stays the same)
+      for (var i = 0; i < N && i < newData.length; i++) {
+        hx[i] = newData[i].hx;
+        hy[i] = newData[i].hy;
+      }
+    }, 300);
+  });
+})();


### PR DESCRIPTION
## Summary

- **Fix pretext text wrapping** — Replaced the fragile CSS `shape-outside` float hack in `pretext-flow.js` with chenglou's actual pretext library (`prepareWithSegments()` + `layoutNextLine()`). Per-line variable-width layout now flows text properly around the mirror ball. Relaxed CSS containment on `.post` to prevent clipping.
- **Poetry Game of Life** — New `poetry` layout renders poems as a Conway's Game of Life cellular automaton on canvas. Pretext's `layoutWithLines()` maps characters to a grid, then cells evolve through ~28 generations before morphing back to readable text. Hover to pause, click to reset.
- **Quotes n-body gravity** — New `quotes` layout turns every character into a gravitational particle. Pairwise forces computed via spatial hash (O(n*k)), with homing springs that cycle between readable text → gravitational drift → reform. Each of the 11 quotes gets its own neon color. Drag to attract, click to scatter, double-click to reform.

## Files changed (13 files, +940 −104)

| File | Change |
|---|---|
| `assets/js/pretext-flow.js` | Rewritten to use `@chenglou/pretext` from CDN |
| `assets/js/poetry-life.js` | **New** — Game of Life engine |
| `assets/js/quotes-gravity.js` | **New** — N-body gravity simulation |
| `_layouts/poetry.html` | **New** — Poetry layout with canvas |
| `_layouts/quotes.html` | **New** — Quotes layout with canvas |
| `_layouts/default.html` | Added script tags for new JS |
| `assets/css/style.css` | Poetry + quotes canvas styles, relaxed containment |
| `_poetry/*.md` (5 files) | `layout: post` → `layout: poetry` |
| `_pages/quotes.md` | `layout: post` → `layout: quotes` |

## Test plan

- [ ] Visit a blog post — mirror ball should follow cursor with text wrapping around it
- [ ] Visit a poetry page (e.g. /poetry/god-hand/) — text should render on canvas, evolve through Game of Life, then reform
- [ ] Visit /quotes/ — characters should display readable, then scatter under gravity, then reform
- [ ] Test drag/click/double-click interactions on the quotes canvas
- [ ] Test hover-to-pause and click-to-reset on poetry canvas
- [ ] Verify pages degrade gracefully if CDN is unreachable (no JS errors, content still accessible via sr-only source divs)

https://claude.ai/code/session_01TKngGqCHgPQNbaoQ4Zm3Dz